### PR TITLE
Quick bugfix in loading fort3.limi

### DIFF
--- a/sixtracktools/sixinput.py
+++ b/sixtracktools/sixinput.py
@@ -757,7 +757,7 @@ class SixInput(object):
                 currline = next(f3)
                 self.aperturelimitations = {}
                 if 'LOAD' in currline:
-                    apfh=open(currline.split()[1].strip())
+                    apfh=open(basedir + '/' + currline.split()[1].strip())
                     for line in apfh:
                         if line.startswith('/'):
                             continue


### PR DESCRIPTION
Quick fix: fort3.limi file loading is now with respect to the base dir of the sixtrackinput.